### PR TITLE
Remove 10 second delay on async decode.

### DIFF
--- a/ReplayDecoder/Replay.cs
+++ b/ReplayDecoder/Replay.cs
@@ -731,7 +731,6 @@ namespace ReplayDecoder
 
         private async Task<Replay?> ContinueDecoding() 
         {
-            await Task.Delay(TimeSpan.FromSeconds(10));
             for (int a = (int)StructType.frames; a < ((int)StructType.pauses) + 1; a++) {
                 StructType type = (StructType)await DecodeByte(stream);
 


### PR DESCRIPTION
Not sure why it's there, seems to work fine without.